### PR TITLE
Add support for CPLEX verbose/silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ suppresses output.
 The action of `set_solver_verbose` is through `set_solver_options`.
 
 At present, this function only knows how to do this for the `Cbc`, `GLPK`,
-`Gurobi`, and `HiGHS` optimizers.
+`Gurobi`, `HiGHS` and `CPLEX` optimizers.

--- a/src/set_verbose.jl
+++ b/src/set_verbose.jl
@@ -1,6 +1,6 @@
 """
 The `_solver_table` maps solver Modules as Symbols (e.g., `:Cbc`) to 
-a pair `(name, verbose, quite)` values.
+a pair `(name, verbose, quiet)` values.
 """
 _solver_table = Dict{String,Tuple{String,Any,Any}}()
 
@@ -8,6 +8,7 @@ _solver_table["Cbc"] = ("LogLevel", 1, 0)
 _solver_table["Gurobi"] = ("OutputFlag", 1, 0)
 _solver_table["GLPK"] = ("msg_lev", 2, 0)
 _solver_table["HiGHS"] = ("output_flag", true, false)
+_solver_table["CPLEX"] = ("CPXPARAM_ScreenOutput", 1, 0)
 
 
 """


### PR DESCRIPTION
Hi, I haven´t used this package myself yet as I am sticking to CPLEX.jl as my solver for the meantime but I can see how useful it is and will probably use it in the future.
I added the capability of accessing the CPLEX solver output flag via [this](https://www.ibm.com/docs/en/icos/12.8.0.0?topic=parameters-messages-screen-switch) and fixed a small typo error (quite to quiet).
I have tested it myself and it works so hopefully this pr can be useful for the project.